### PR TITLE
Documentation - Standardize Readme to Answer What, Where, How, and Who AND Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Sam Bumgardner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# ld-52-harvest
+A game originally created for the Ludum Dare 52 game jam in 72 hours.
+
+## Play the Game
+[Play on itch.io](https://nbumgardner.itch.io/ludum-dare-52)
+
+It's time to hit the fields and farm some points in _Farming Combos_, a fast-paced action/puzzle game!
+
+## How to Run Project Locally
+To run the project locally:
+
+1. Open the project with the Godot editor.
+2. Click the play button (shortcut F5) in the top-right corner.
+
+## Credits
+Team members include:
+
+- Sam Bumgardner - lead designer, programmer, misc. goalpost-moving
+- Noah Bumgardner - designer, programmer, composer
+- Alex Mullins - artist, created the harvest / plant symbols and crop-tile graphics
+- Tom Bumgardner - artist, made a painting for the thumbnail / menu screens
+
+### Attributions
+Closed source resources used:
+
+- [7Soul’s RPG Graphics - Tiles - Grasslands](https://7soul.itch.io/7souls-rpg-graphics-tiles-grasslands) by Henrique "7Soul" Lazarini - @7SoulDesign
+
+Open source resources used:
+
+- [Roboto](https://fonts.google.com/specimen/Roboto) font by Christian Robertson.
+
+Coded using the [Godot](https://godotengine.org) game engine.
+
+The original game jam version, tagged as `ld52-submission` and [hosted on itch.io](https://nbumgardner.itch.io/ludum-dare-52), runs on Godot version 3.x.
+
+### License
+This game's code is open-source under the MIT License.
+Please ask the original artists before using any art or audio assets in a different context.


### PR DESCRIPTION
Standardize the readmes of GitHub repositories for Ludum Dare game jams I have contributed to.

## Implementation Details

Update the `README.md` file to mention the game name, where to play it, how to run the project, and credits. Also add the missing MIT license.